### PR TITLE
[SP-9575] stringify multipart object params

### DIFF
--- a/lib/languages/js/helpers/index.js
+++ b/lib/languages/js/helpers/index.js
@@ -38,7 +38,7 @@ helpers.setParam = function(param) {
     case 'body':
       return `if ('undefined' !== typeof params.${param.name}) { req.data = params.${param.name}; }`;
     case 'multipart':
-      return `if ('undefined' !== typeof params.${param.name}) { req.data.${param.name} = params.${param.name}; }`;
+      return `if ('undefined' !== typeof params.${param.name}) { req.data.${param.name} = ${param.type === 'object' ? `JSON.stringify(params.${param.name})` : `params.${param.name}`}; }`;
     default:
       throw new Error(`Bad param placement ${param.in}`);
   }


### PR DESCRIPTION
SP-9575

PR 1 of 2 (the other shall be on bravado-core to convert the stringified object back into an actual object before schema validation)

if we do not do this then the `form_data` module blows up because it expects something stream-like for multipart params