### PR TITLE
[SP-9830] add option to exclude private schemas when generating client

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,7 +29,7 @@ const checkForUnresolvedRefs = (refs) => {
   });
 };
 
-const resolveSchemaRefs = (api, refs) => {
+const resolveSchemaRefs = (api, refs, includePrivate) => {
   const result = {};
 
   refs = refs.map((ref) => { return ref.replace('#/definitions/', ''); });
@@ -40,6 +40,7 @@ const resolveSchemaRefs = (api, refs) => {
     const schema = api.definitions[ref];
     if (ref === 'common') { return; }
     if (!schema) { throw new Error(`Missing Ref: #/definitions/${ref}`); }
+    if (!includePrivate && schema.private) { return; }
     if (!schema.title) { throw new Error(`Missing Title: #/definitions/${ref}`); }
     if (!schema.description) { throw new Error(`Missing Description: #/definitions/${ref}`); }
     const example = api.examples[ref];
@@ -62,7 +63,8 @@ module.exports = async (options) => {
   options = defaults(options, {
     version: '*',
     lang: 'js',
-    output: '.'
+    output: '.',
+    includePrivate: true
   });
   options.output = path.resolve(options.output);
 
@@ -84,7 +86,7 @@ module.exports = async (options) => {
   const apiDef = resolvedExamples.resolved;
 
   debug('resolving refs', options.lang);
-  apiDef.schemaMap = resolveSchemaRefs(apiDef, extractSchemaRefs(apiDef.resources));
+  apiDef.schemaMap = resolveSchemaRefs(apiDef, extractSchemaRefs(apiDef.resources), options.includePrivate);
 
   if (await fs.pathExists(`${options.output}/LICENSE`)) {
     options.license = await fs.readFile(`${options.output}/LICENSE`);


### PR DESCRIPTION
SP-9830

this will allow us to pass an `includePrivate` option and exclude entire schemas if the relevant endpoint is private (e.g. `userPost` doesn't need to be included in the publicly available rest client)

part 1 of Grand Implementation Plan - if/when merged can update relevant schema definitions in losant-models