### PR TITLE
[SP-12088] multipart support strings as files

### DIFF
--- a/lib/languages/js/helpers/index.js
+++ b/lib/languages/js/helpers/index.js
@@ -38,7 +38,7 @@ helpers.setParam = function(param) {
     case 'body':
       return `if ('undefined' !== typeof params.${param.name}) { req.data = params.${param.name}; }`;
     case 'multipart':
-      return `if ('undefined' !== typeof params.${param.name}) { req.data.${param.name} = ${param.type === 'object' ? `JSON.stringify(params.${param.name})` : `params.${param.name}`}; }`;
+      return `if ('undefined' !== typeof params.${param.name}) { req.data.${param.name} = params.${param.name}; }`;
     default:
       throw new Error(`Bad param placement ${param.in}`);
   }

--- a/lib/languages/js/templates/api.js.tpl
+++ b/lib/languages/js/templates/api.js.tpl
@@ -48,11 +48,17 @@ module.exports = function (options) {
     if (opts.acceptVersion) {
       req.headers['Accept-Version'] = opts.acceptVersion;
     }
-    if (opts.multipart) {
+    if (opts.multipartTypes) {
       var data = req.data || {};
       req.data = new FormData();
       Object.keys(data).forEach(function(key) {
-        req.data.append(key, data[key]);
+        if(opts.multipartTypes[key] === 'object') {
+          req.data.append(key, JSON.stringify(data[key]));
+        } else if (opts.multipartTypes[key] === 'file' && typeof(data[key]) === 'string') {
+          req.data.append(key, data[key], { filename: key });
+        } else {
+          req.data.append(key, data[key]);
+        }
       });
       if (req.data.getHeaders) {
         req.headers = Object.assign(req.data.getHeaders(), req.headers);

--- a/lib/languages/js/templates/resource.js.tpl
+++ b/lib/languages/js/templates/resource.js.tpl
@@ -60,7 +60,7 @@ module.exports = function (options, client) {
     } else if (!opts) {
       opts = {};
     }{{#if (isMultipart action.params)}}
-    opts.multipart = true;{{/if}}
+    opts.multipartTypes = {};{{/if}}
     params = params || {};
     var tpl = uriTemplate.parse('{{{joinPath ../api.basePath ../resource.path action.path}}}');
     var pathParams = {};
@@ -71,7 +71,8 @@ module.exports = function (options, client) {
       params: { _actions: false, _links: true, _embedded: true }
     };
     {{#definedParams ../api ../resource action true}}
-    {{{setParam .}}}
+    {{#eq in 'multipart'}}opts.multipartTypes.{{name}} = '{{type}}';
+    {{/eq}}{{{setParam .}}}
     {{/definedParams}}
     req.url = tpl.expand(pathParams);
     return client.request(req, opts, cb);


### PR DESCRIPTION
SP-12088 - if a string is passed in on a param where a file (i.e., stream or file object) is expected assume the string is the file content and do the right thing for the form data append.